### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/leapone/03164a49-2132-4857-b429-ec7114e99821/06ef6ab3-192a-455b-a6ab-d2fc81390de8/_apis/work/boardbadge/f4091e22-f3f6-4ce6-b53a-1a6040c34914)](https://dev.azure.com/leapone/03164a49-2132-4857-b429-ec7114e99821/_boards/board/t/06ef6ab3-192a-455b-a6ab-d2fc81390de8/Microsoft.RequirementCategory)
 # doca-repos-1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/leapone/03164a49-2132-4857-b429-ec7114e99821/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.